### PR TITLE
Notes for colorama pip package to add terminal colors on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Installation
 2.  Install `yewtube` using `pipx install git+https://github.com/iamtalhaasghar/yewtube.git`
 3.  Now, type `yt` That's it.
 
+## Terminal Colors on Windows (Optional)
+Install **_colorama_**
+- For **_pip_**, simply use `pip install colorama`
+- For **_pipx_**, use `pipx runpip yewtube install colorama`
+
 What's new in yewtube?
 ----------------------
 -   **No Youtube API Key required**


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->
Just thought it would be a good idea to have a note in the documentation about adding Colorama on Windows systems to enable colors in the terminal.

## Issue / Suggestion
<!--- If you're describing a bug, tell us what error you are experiencing -->
<!--- Tell us which command you entered inside yewtube that caused the bug so that we can recreate the problem on our end to analyse problem -->
<!--- If you're suggesting a change/improvement, tell us how it should work -->
I have prepared a pull request that would cover both an install with `pip` and for the recommended `pipx` installation methods in `README.md`.
