### PR TITLE
players/mpv: Enable quit-watch-later

### DIFF
--- a/mps_youtube/players/mpv.py
+++ b/mps_youtube/players/mpv.py
@@ -292,7 +292,7 @@ def _get_input_file():
     conf = conf.replace("playlist_next", "quit")
     conf = conf.replace("pt_step 1", "quit")
     standard_cmds = ['q quit 43\n', '> quit\n', '< quit 42\n', 'NEXT quit\n',
-                     'PREV quit 42\n', 'ENTER quit\n']
+                     'PREV quit 42\n', 'ENTER quit\n', 'Q quit-watch-later']
     bound_keys = [i.split()[0] for i in conf.splitlines() if i.split()]
 
     for i in standard_cmds:


### PR DESCRIPTION
Allows pressing shift-q to quit so mpv saves the video position and allows resuming on next play

This branch is based on master as upstream devel branch is some commits behind master.

Happy to help if this PR doesn't fit the usual development flow. Thanks and regards,