### PR TITLE
Implement 'shuffle all' and 'play all'

### DIFF
--- a/mps_youtube/commands/play.py
+++ b/mps_youtube/commands/play.py
@@ -9,6 +9,11 @@ from . import RS, WORD, command
 from .search import related, yt_url
 from .songlist import plist
 
+@command(r'play all', 'play all')
+def play_loaded():
+    g.model.songs = content.get_last_query()
+    if g.model.songs:
+        play_all("", "", "")
 
 @command(r'play\s+(%s|\d+)' % WORD, 'play')
 def play_pl(name):

--- a/mps_youtube/commands/songlist.py
+++ b/mps_youtube/commands/songlist.py
@@ -208,6 +208,16 @@ def shuffle_fn():
     g.message = c.y + "Items shuffled" + c.w
     g.content = content.generate_songlist_display()
 
+@command(r'shuffle all', 'shuffle all')
+def shuffle_playlist():
+    """ Shuffle entire loaded playlist. """
+    songs = content.get_last_query()
+
+    if songs: 
+        random.shuffle(songs)
+        paginatesongs(list(songs))
+        g.message = c.y + "Shuffled entire playlist" + c.w
+        g.content = content.generate_songlist_display()
 
 @command(r'reverse', 'reverse')
 def reverse_songs():
@@ -231,19 +241,9 @@ def reverse_songs_range(lower, upper):
 @command(r'reverse all', 'reverse all')
 def reverse_playlist():
     """ Reverse order of entire loaded playlist. """
-    # Prevent crash if no last query
-    if g.last_search_query == (None, None) or \
-            'func' not in g.last_search_query[1]:
-        g.content = content.logo()
-        g.message = "No playlist loaded"
-        return
+    songs = content.get_last_query()
 
-    songs_list_or_func = g.last_search_query[1]['func']
-    if callable(songs_list_or_func):
-        songs = reversed(songs_list_or_func(0,None))
-    else:
-        songs = reversed(songs_list_or_func)
-
-    paginatesongs(list(songs))
-    g.message = c.y + "Reversed entire playlist" + c.w
-    g.content = content.generate_songlist_display()
+    if songs:   
+        paginatesongs(list(reversed(songs)))
+        g.message = c.y + "Reversed entire playlist" + c.w
+        g.content = content.generate_songlist_display()

--- a/mps_youtube/content.py
+++ b/mps_youtube/content.py
@@ -259,3 +259,19 @@ def qrcode_display(url):
     qr.add_data(url)
     qr.print_ascii(out=buf)
     return buf.getvalue()
+
+def get_last_query():
+    # Prevent crash if no last query
+    if g.last_search_query == (None, None) or \
+            'func' not in g.last_search_query[1]:
+        g.content = logo()
+        g.message = "No playlist loaded"
+        return
+
+    songs_list_or_func = g.last_search_query[1]['func']
+    if callable(songs_list_or_func):
+        songs = songs_list_or_func(0,None)
+    else:
+        songs = songs_list_or_func
+
+    return songs

--- a/mps_youtube/helptext.py
+++ b/mps_youtube/helptext.py
@@ -93,8 +93,9 @@ def helptext():
     {2}mix <number>{1} - show YouTube mix playlist from item in results.
 
     {2}shuffle{1} - Shuffle the displayed results.
+    {2}shuffle all{1} - Shuffle entire loaded playlist.
     {2}reverse{1} or {2}reverse <number>-<number>{1} - Reverse the displayed items or item range.
-    {2}reverse all{1} - Reverse order of entire loaded playlist
+    {2}reverse all{1} - Reverse order of entire loaded playlist.
     """.format(c.ul, c.w, c.y)),
 
         ("download", "Downloading and Playback", """


### PR DESCRIPTION
Resolves #73 and implement `play all` to play the entire loaded playlist from start to end, though currently playing songs are not paginated and can be improved in that respect.

Apologies for the cheesiness and not strictly following CONTRIBUTING.md, the `develop` branch is slightly behind.

If I'm doing something wrong, let me know, I'm still learning coding & the OSS etiquette.