### PR TITLE
Disable `selected_pafy_pls_id` (soft revert: d69a959)

### DIFF
--- a/mps_youtube/commands/local_playlist.py
+++ b/mps_youtube/commands/local_playlist.py
@@ -104,7 +104,7 @@ def save_last():
 
         # save using artist name in postion 1
         if g.model:
-            saveas = g.pafy_pls[g.selected_pafy_pls_id][0].info['info']['title']
+            saveas = g.model[0].title[:18].strip()
             saveas = re.sub(r"[^-\w]", "-", saveas, flags=re.UNICODE)
 
         # loop to find next available name
@@ -153,7 +153,7 @@ def open_save_view(action, name):
             g.content = content.generate_songlist_display()
 
         else:
-            g.userpl[name] = Playlist(name, [Video(i['id'], i['title'], parse_video_length(i['duration'])) for i in g.pafy_pls[g.selected_pafy_pls_id][0].videos])
+            g.userpl[name] = Playlist(name, list(g.model.songs))
             g.message = util.F('pl saved') % name
             playlists.save()
             g.content = content.generate_songlist_display()

--- a/mps_youtube/commands/play.py
+++ b/mps_youtube/commands/play.py
@@ -55,8 +55,7 @@ def play(pre, choice, post=""):
     if g.browse_mode == "ytpl":
 
         if choice.isdigit():
-            g.selected_pafy_pls_id = g.ytpls[int(choice)-1]['link']
-            return plist(g.selected_pafy_pls_id)
+            return plist(g.ytpls[int(choice) - 1]['link'])
         else:
             g.message = "Invalid playlist selection: %s" % c.y + choice + c.w
             g.content = content.generate_songlist_display()

--- a/mps_youtube/g.py
+++ b/mps_youtube/g.py
@@ -47,7 +47,6 @@ userhist = {}
 pafs = collections.OrderedDict()
 streams = collections.OrderedDict()
 pafy_pls = {}  #
-selected_pafy_pls_id = ''
 last_opened = message = content = ""
 suffix = "3" # Python 3
 OLD_CFFILE = os.path.join(paths.get_config_dir(), "config")


### PR DESCRIPTION
Fixes: https://github.com/iamtalhaasghar/yewtube/issues/75

Reverted commit intends to enable full playlist download (non-paginated).
The change introduces bug when view does not set `g.selected_pafy_pls_id`
prior to `save`.

This functionality was already available via `dump` command:
```
dump - to show entire contents of an opened YouTube playlist.
             (useful for playing or saving entire playlists, use undump to     undo)
```

Testing:
```
$ tail -n 5 ~/.config/mps-youtube/input_history
pl UUOkFff6Mg5YEyeZ8XONGc9A
save test_pl_nodump
dump
save test_pl_withdump
ls
      19  test_pl_nodump      36      38:30:36
      20  test_pl_withdump    177     130:33:26
```