### PR TITLE
remove pyreadline dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests
-pyreadline ; platform_system=="Linux"
 pyreadline3 ; platform_system=="Windows"
 pyperclip
 youtube-search-python


### PR DESCRIPTION
It's unmaintained and yewtube works fine without it.

I looked at the code, and it only seems to use functions from the `readline` module that is present in the standard library. I don't know about windows, so I'm leaving there pyreadline3